### PR TITLE
Add tslint-consistent-codestyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unversioned
+* Added tslint-consistent-codestyle as peer dependency
+* Fixed naming convention for React related names
+
 ## 0.1.1 - 2018-08-31
 * deactivated mocha specific rules
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,123 @@
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
 
+// [tslint]
+const tslintRules = {
+  // [tslint] - deactivate
+  'variable-name': false, // see [tslint-consistent-codestyle].naming-convention
+  // [tslint] - configure
+  'align': [true, 'arguments', 'statements', 'members', 'elements'],
+  'no-unused-expression': [true, 'allow-fast-null-checks'],
+  'prefer-method-signature': true,
+  'quotemark': [true, 'single', 'jsx-double'],
+  'strict-boolean-expressions': [
+    true, 'allow-undefined-union',
+  ],
+  'trailing-comma': [
+    true, {
+      'multiline': 'always',
+      'singleline': 'never',
+      // Disallowes ',' after rest parameters
+      'esSpecCompliant': true,
+    },
+  ],
+  'typedef': [
+    true,
+    'call-signature',
+    'arrow-call-signature',
+    'parameter',
+    // 'arrow-parameter', // use the inferred types
+    // 'variable-declaration', // use the inferred types
+    'member-variable-declaration',
+    'property-declaration',
+  ],
+};
+// ================================================
+// [tslint-microsoft-contrib]
+const tslintMicrosoftContribRules = {
+  // [tslint-microsoft-contrib] - deactivate
+  'function-name': false, // see [tslint-consistent-codestyle].naming-convention
+  'no-relative-imports': false,
+  'missing-jsdoc': false,
+  'mocha-avoid-only': false,
+  'mocha-no-side-effect-code': false,
+  'mocha-unneeded-done': false,
+
+  // [tslint-microsoft-contrib] - configure
+  'export-name': true,
+  'import-name': [
+    true, {
+      'reactFontawesome': 'FontAwesomeIcon',
+    },
+  ],
+  'react-tsx-curly-spacing': [true, 'never', { 'allowMultiline': true }],
+  'react-unused-props-and-state': true,
+};
+// ================================================
+// [tslint-react]
+const tslintReact = {
+  // [tslint-react] - deactivate
+  'jsx-no-multiline-js': false, // see: react-tsx-curly-spacing
+
+  // [tslint-react] - configure
+  'jsx-boolean-value': [true, 'never'],
+  'jsx-equals-spacing': [true, 'never'],
+  'jsx-key': true,
+  'jsx-no-string-ref': true,
+  'jsx-self-close': true,
+  'jsx-space-before-trailing-slash': true,
+  'jsx-wrap-multiline': true,
+};
+// ================================================
+// [tslint-consistent-codestyle]
+const tslintConsistentCodestyle = {
+  // [tslint-consistent-codestyle] - configure
+  'early-exit': [
+    true, {
+      'max-length': 4
+    }
+  ],
+  "naming-convention": [
+    true,
+    // forbid leading and trailing underscores and enforce camelCase on EVERY name. will be overridden by subtypes if needed
+    { 'type': 'default', 'format': 'camelCase', 'leadingUnderscore': 'forbid', 'trailingUnderscore': 'forbid'},
+    // require all global constants to be camelCase or UPPER_CASE
+    // all other variables and functions still need to be camelCase
+    { 'type': 'variable', 'modifiers': ['global', 'const'], 'format': ['camelCase', 'UPPER_CASE'] },
+    // override the above format option for exported constants to allow only PascalCase
+    { 'type': 'variable', 'modifiers': ['export', 'const'], 'format': 'PascalCase' },
+    // require exported constant variables that are initialized with functions to be PascalCase
+    { 'type': 'functionVariable', 'modifiers': ['export', 'const'], 'format': 'PascalCase' },
+    // Except for and HOCs - they should be camelCase (they start with the prefix 'with')
+    { 'type': 'functionVariable', 'modifiers': ['export', 'const'], 'format': 'camelCase', 'filter': '^with' },
+    // This rule usually applies for any HOC that has a parameter with the suffix 'Component' passed.
+    // Since this parameter describes a type, we want to enforce PascalCase
+    { 'type': 'parameter', 'format': 'PascalCase', 'filter': '^(Wrapped)?Component$' },
+    // exclicitly disable the format check only for method toJSON
+    { 'type': 'method', 'filter': '^toJSON$', 'format': null },
+    // enforce UPPER_CASE for all public static readonly(!) properties
+    { 'type': 'property', 'modifiers': ['public', 'static', 'const'], 'format': 'UPPER_CASE'},
+    // enforce PascalCase for classes, interfaces, enums, etc. Remember, there are still no underscores allowed.
+    { 'type': 'type', 'format': 'PascalCase' },
+    // Enforce prefix 'Abstract' for abstract classes
+    { 'type': 'class', 'modifiers': 'abstract', 'prefix': 'Abstract' },
+    // Interfaces shall start with an capital I
+    { 'type': 'interface', 'prefix': 'I' },
+    // generic type parameters must start with 'T' or 'U'
+    { 'type': 'genericTypeParameter', 'regex': '^[TU].*$' },
+    // Override 'public static const' format here with PascalCase
+    { 'type': 'enumMember', 'format': 'PascalCase'}
+  ],
+  'no-accessor-recursion': true,
+  'no-collapsible-if': true,
+  'no-static-this': true,
+  'no-unnecessary-else': true,
+  'no-var-before-return': true,
+  'object-shorthand-properties-first': true,
+  'prefer-const-enum': true,
+};
+
+
 module.exports = {
   extends: [
     'tslint:latest',
@@ -13,71 +130,11 @@ module.exports = {
 
   defaultSeverity: 'error',
 
+  rulesDirectory: ["tslint-consistent-codestyle"],
   rules: {
-    // [tslint]
-    // [tslint] - configure
-    'align': [true, 'arguments', 'statements', 'members', 'elements'],
-    'prefer-method-signature': true,
-    'quotemark': [true, 'single', 'jsx-double'],
-    'strict-boolean-expressions': [
-      true, 'allow-undefined-union',
-    ],
-    'trailing-comma': [
-      true, {
-        'multiline': 'always',
-        'singleline': 'never',
-        // Disallowes ',' after rest parameters
-        'esSpecCompliant': true,
-      },
-    ],
-    'typedef': [
-      true,
-      'call-signature',
-      'arrow-call-signature',
-      'parameter',
-      // 'arrow-parameter', // use the inferred types
-      // 'variable-declaration', // use the inferred types
-      'member-variable-declaration',
-      'property-declaration',
-    ],
-
-    // ================================================
-    // [tslint-microsoft-contrib]
-    // [tslint-microsoft-contrib] - deactivate
-    'no-relative-imports': false,
-    'missing-jsdoc': false,
-    'mocha-avoid-only': false,
-    'mocha-no-side-effect-code': false,
-    'mocha-unneeded-done': false,
-
-    // [tslint-microsoft-contrib] - configure
-    'export-name': true,
-    'import-name': [
-      true, {
-        'reactFontawesome': 'FontAwesomeIcon',
-      },
-    ],
-    'function-name': [
-      true, {
-        // override that static methods should start upper case
-        'static-method-regex': '^[a-z][\\w\\d]+$',
-      },
-    ],
-    'react-tsx-curly-spacing': [true, 'never', { 'allowMultiline': true }],
-    'react-unused-props-and-state': true,
-
-    // ================================================
-    // [tslint-react]
-    // [tslint-react] - deactivate
-    'jsx-no-multiline-js': false, // see: react-tsx-curly-spacing
-
-    // [tslint-react] - configure
-    'jsx-boolean-value': [true, 'never'],
-    'jsx-equals-spacing': [true, 'never'],
-    'jsx-key': true,
-    'jsx-no-string-ref': true,
-    'jsx-self-close': true,
-    'jsx-space-before-trailing-slash': true,
-    'jsx-wrap-multiline': true,
+    ...tslintRules,
+    ...tslintMicrosoftContribRules,
+    ...tslintReact,
+    ...tslintConsistentCodestyle
   },
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "tslint": "^5.11.0",
+    "tslint-consistent-codestyle": "1.13.3",
     "tslint-microsoft-contrib": "^5.2.1",
     "tslint-react": "^3.6.0",
     "typescript": "^3.0.0"


### PR DESCRIPTION
- Organized rules by extension
- Improved naming convention for React related namings

Added the following rules:
- [no-accessor-recursion](https://github.com/ajafff/tslint-consistent-codestyle/blob/master/docs/no-accessor-recursion.md)
- [no-collapsible-if](https://github.com/ajafff/tslint-consistent-codestyle/blob/master/docs/no-collapsible-if.md)
- [no-static-this](https://github.com/ajafff/tslint-consistent-codestyle/blob/master/docs/no-static-this.md)
- [no-unnecessary-else](https://github.com/ajafff/tslint-consistent-codestyle/blob/master/docs/no-unnecessary-else.md)
- [no-var-before-return](https://github.com/ajafff/tslint-consistent-codestyle/blob/master/docs/no-var-before-return.md)
- [object-shorthand-properties-first](https://github.com/ajafff/tslint-consistent-codestyle/blob/master/docs/object-shorthand-properties-first.md)
- [prefer-const-enum](https://github.com/ajafff/tslint-consistent-codestyle/blob/master/docs/prefer-const-enum.md)