### PR TITLE
Version 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unversioned
 * Added tslint-consistent-codestyle as peer dependency
 * Fixed naming convention for React related names
+* Added 'allow-string' option to strict-boolean-expressions
 
 ## 0.1.1 - 2018-08-31
 * deactivated mocha specific rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## Unversioned
+## 0.1.2 - 2018-09-06
 * Added tslint-consistent-codestyle as peer dependency
 * Fixed naming convention for React related names
 * Added 'allow-string' option to strict-boolean-expressions

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const tslintRules = {
   'prefer-method-signature': true,
   'quotemark': [true, 'single', 'jsx-double'],
   'strict-boolean-expressions': [
-    true, 'allow-undefined-union',
+    true, 'allow-undefined-union', 'allow-string'
   ],
   'trailing-comma': [
     true, {

--- a/index.js
+++ b/index.js
@@ -89,8 +89,9 @@ const tslintConsistentCodestyle = {
     { 'type': 'variable', 'modifiers': ['global', 'const'], 'format': ['camelCase', 'UPPER_CASE'] },
     // override the above format option for exported constants to allow only PascalCase
     { 'type': 'variable', 'modifiers': ['export', 'const'], 'format': 'PascalCase' },
-    // require exported constant variables that are initialized with functions to be PascalCase
+    // require constant function variables to be PascalCase when they are exported or end with 'SFC'
     { 'type': 'functionVariable', 'modifiers': ['export', 'const'], 'format': 'PascalCase' },
+    { 'type': 'functionVariable', 'modifiers': ['const'], 'format': 'PascalCase', 'filter': 'SFC$' }, // (stateless components)
     // Except for and HOCs - they should be camelCase (they start with the prefix 'with')
     { 'type': 'functionVariable', 'modifiers': ['export', 'const'], 'format': 'camelCase', 'filter': '^with' },
     // This rule usually applies for any HOC that has a parameter with the suffix 'Component' passed.


### PR DESCRIPTION
* Added tslint-consistent-codestyle as peer dependency
* Fixed naming convention for React related names
* Added 'allow-string' option to strict-boolean-expressions